### PR TITLE
Improve responsiveness with async file I/O

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,5 +25,6 @@ tauri-plugin-dialog = "2"
 tauri-plugin-global-shortcut = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread"] }
 
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 use tauri::{Manager, Window};
 use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
-use std::fs;
+use tokio::fs;
 use std::path::PathBuf;
 
 // commands for file operations
@@ -43,7 +43,7 @@ async fn open_file_with_confirmation(window: Window, has_unsaved_changes: bool) 
         Some(file_path) => {
             let path_buf = PathBuf::from(file_path.to_string());
             let path_str = path_buf.to_string_lossy().to_string();
-            match fs::read_to_string(&path_buf) {
+            match fs::read_to_string(&path_buf).await {
                 Ok(content) => {
                     // Update title immediately
                     let filename = path_buf.file_name()
@@ -73,7 +73,7 @@ async fn save_file(window: Window, file_path: Option<String>, content: String) -
         }
     };
     
-    match fs::write(&path, content) {
+    match fs::write(&path, content).await {
         Ok(_) => {
             // Update title immediately
             let filename = std::path::Path::new(&path)
@@ -95,7 +95,7 @@ async fn save_as_file(window: Window, content: String) -> Result<Option<String>,
         Some(file_path) => {
             let path_buf = PathBuf::from(file_path.to_string());
             let path_str = path_buf.to_string_lossy().to_string();
-            match fs::write(&path_buf, content) {
+            match fs::write(&path_buf, content).await {
                 Ok(_) => {
                     // Update title immediately
                     let filename = path_buf.file_name()

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,15 @@ let isModified = false;
 let editor;
 let titleUpdatePending = false;
 
+// simple debounce utility
+function debounce(fn, delay) {
+    let timer;
+    return (...args) => {
+        clearTimeout(timer);
+        timer = setTimeout(() => fn(...args), delay);
+    };
+}
+
 const invoke = window.__TAURI__.core.invoke;
 
 // Debounced title update to avoid excessive calls
@@ -36,7 +45,7 @@ function init() {
     }
     
     // optimized event listeners
-    editor.addEventListener('input', onEditorChange, { passive: true });
+    editor.addEventListener('input', debounce(onEditorChange, 100), { passive: true });
     document.addEventListener('keydown', handleKeyboardShortcuts);
     
     // Initialize


### PR DESCRIPTION
## Summary
- use `tokio::fs` for file operations
- add `tokio` runtime dependency
- debounce editor input events

## Testing
- `cargo check` *(fails: glib-2.0 not found)*
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68414b765a5c8324ba9ba80a19ff6662